### PR TITLE
pybullet_egl_mwe: Add option to avoid forcing the use of Nvidia GPU

### DIFF
--- a/pybullet_egl_mwe.py
+++ b/pybullet_egl_mwe.py
@@ -6,15 +6,24 @@ import pybullet as pb
  
  
 _client_id = pb.connect(pb.DIRECT)
-os.environ['CUDA_VISIBLE_DEVICES'] = '0'
-assert 'CUDA_VISIBLE_DEVICES' in os.environ
-devices = os.environ.get('CUDA_VISIBLE_DEVICES', ).split(',')
-device_id = str(devices[-1])
-out = subprocess.check_output(['nvidia-smi', '--id='+device_id, '-q', '--xml-format'])
-tree = ET.fromstring(out)
-gpu = tree.findall('gpu')[0]
-dev_id = gpu.find('minor_number').text
-os.environ['EGL_VISIBLE_DEVICES'] = str(dev_id)
+
+# These code snippet is used to force EGL to use the NVIDIA GPU
+# if that is not available, avoid to set EGL_VISIBLE_DEVICES by commenting the `os.environ['EGL_VISIBLE_DEVICES'] = str(dev_id)`
+# or setting use_nvidia_gpu to False
+# line and the `eglRenderer` will work fine with software emulated OpenGL
+use_nvidia_gpu = True
+
+if use_nvidia_gpu:
+    os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+    assert 'CUDA_VISIBLE_DEVICES' in os.environ
+    devices = os.environ.get('CUDA_VISIBLE_DEVICES', ).split(',')
+    device_id = str(devices[-1])
+    out = subprocess.check_output(['nvidia-smi', '--id='+device_id, '-q', '--xml-format'])
+    tree = ET.fromstring(out)
+    gpu = tree.findall('gpu')[0]
+    dev_id = gpu.find('minor_number').text
+    os.environ['EGL_VISIBLE_DEVICES'] = str(dev_id)
+
 egl = pkgutil.get_loader('eglRenderer')
 assert egl
 pb.loadPlugin(egl.get_filename(), "_eglRendererPlugin", physicsClientId=_client_id) # Fails here


### PR DESCRIPTION
This permits to check if everything is working on system where for some reason the EGL on Nvidia is not working (for example on systems where the NVIDIA driver was installed manually and either the ICD's json or `libEGL_nvidia.so` is not installed.